### PR TITLE
MAV status message

### DIFF
--- a/mav_msgs/msg/Status.msg
+++ b/mav_msgs/msg/Status.msg
@@ -1,0 +1,27 @@
+Header header
+
+float32     battery_voltage
+string      flight_mode_ll
+string      state_estimation
+string      position_control
+bool        serial_interface_enabled
+bool        serial_interface_active
+float32     flight_time
+float32     cpu_load
+
+string      motor_status
+
+string      gps_status
+int32       gps_num_satellites 
+
+int32       debug1
+int32       debug2
+
+bool        have_SSDK_parameters
+
+uint32      tx_packets
+uint32      tx_packets_good
+uint32      rx_packets
+uint32      rx_packets_good
+
+float32     timesync_offset


### PR DESCRIPTION
added old message from asctec_hl_comm as reference / to start discussions
we should also have a look at the pixhawk status message: https://pixhawk.ethz.ch/mavlink/#SYS_STATUS

This message should only contain the essential status information. Deatails info can also be published via ros diagnostics:
http://wiki.ros.org/diagnostics
https://github.com/ethz-asl/asctec_mav_framework/blob/master/asctec_hl_interface/src/hl_interface.cpp#L363