### PR TITLE
removed eigen stdvector

### DIFF
--- a/mav_msgs/include/mav_msgs/conversions.h
+++ b/mav_msgs/include/mav_msgs/conversions.h
@@ -23,7 +23,6 @@
 #ifndef MAV_MSGS_CONVERSIONS_H
 #define MAV_MSGS_CONVERSIONS_H
 
-#include <Eigen/StdVector>
 #include <geometry_msgs/Point.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/Quaternion.h>


### PR DESCRIPTION
Removed Eigen/StdVector 
For C++11 builds it is not needed and some picky compilers will actually throw the following error if it is included

"eigen3/Eigen/src/StlSupport/StdVector.h:69:9: error: partial specialization of 'std::vector<T, Eigen::aligned_allocator<U> >' after instantiation of 'std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >' [-fpermissive]
   class vector<T,EIGEN_ALIGNED_ALLOCATOR<T> >"

@rikba this is why your latest pull request in mav_mbzirc won't build