### PR TITLE
Feature/full state motor speeds

### DIFF
--- a/mav_msgs/include/mav_msgs/common.h
+++ b/mav_msgs/include/mav_msgs/common.h
@@ -23,10 +23,10 @@
 #ifndef MAV_MSGS_COMMON_H
 #define MAV_MSGS_COMMON_H
 
-#include <Eigen/Geometry>
 #include <geometry_msgs/Point.h>
 #include <geometry_msgs/Quaternion.h>
 #include <geometry_msgs/Vector3.h>
+#include <Eigen/Geometry>
 
 namespace mav_msgs {
 
@@ -34,7 +34,6 @@ namespace mav_msgs {
 /// [rad] (from wikipedia).
 inline double MagnitudeOfGravity(const double height,
                                  const double latitude_radians) {
-
   // gravity calculation constants
   const double kGravity_0 = 9.780327;
   const double kGravity_a = 0.0053024;
@@ -45,8 +44,8 @@ inline double MagnitudeOfGravity(const double height,
   double sin_squared_twice_latitude =
       sin(2 * latitude_radians) * sin(2 * latitude_radians);
   return kGravity_0 * ((1 + kGravity_a * sin_squared_latitude -
-                      kGravity_b * sin_squared_twice_latitude) -
-                      kGravity_c * height);
+                        kGravity_b * sin_squared_twice_latitude) -
+                       kGravity_c * height);
 }
 
 inline Eigen::Vector3d vector3FromMsg(const geometry_msgs::Vector3& msg) {

--- a/mav_msgs/include/mav_msgs/common.h
+++ b/mav_msgs/include/mav_msgs/common.h
@@ -153,6 +153,26 @@ inline double getShortestYawDistance(double yaw1, double yaw2) {
   return yaw_mod;
 }
 
+// Calculate the nominal rotor rates given the MAV mass, allocation matrix,
+// angular velocity, angular acceleration, and body acceleration (normalized
+// thrust).
+//
+// [torques, thrust]' = A * n^2, where
+// torques = J * ang_acc + ang_vel x J
+// thrust = m * norm(acc)
+inline void getSquaredRotorSpeedsFromAllocationAndState(
+    const Eigen::MatrixXd& allocation_inv, const Eigen::Vector3d& inertia,
+    double mass, const Eigen::Vector3d& angular_velocity_B,
+    const Eigen::Vector3d& angular_acceleration_B,
+    const Eigen::Vector3d& acceleration_B,
+    Eigen::VectorXd* rotor_rates_squared) {
+  const Eigen::Vector3d torque =
+      inertia.asDiagonal() * angular_acceleration_B +
+      angular_velocity_B.cross(inertia.asDiagonal() * angular_velocity_B);
+  const double thrust_force = mass * acceleration_B.norm();
+  *rotor_rates_squared = allocation_inv * input;
+}
+
 }  // namespace mav_msgs
 
 #endif  // MAV_MSGS_COMMON_H

--- a/mav_msgs/include/mav_msgs/common.h
+++ b/mav_msgs/include/mav_msgs/common.h
@@ -159,6 +159,22 @@ inline double getShortestYawDistance(double yaw1, double yaw2) {
 // [torques, thrust]' = A * n^2, where
 // torques = J * ang_acc + ang_vel x J
 // thrust = m * norm(acc)
+//
+// The allocation matrix A has of a hexacopter is:
+// A = K * B, where
+// K = diag(l*c_T, l*c_T, c_M, c_T),
+//     [ s  1  s -s -1 -s]
+// B = [-c  0  c  c  0 -c]
+//     [-1  1 -1  1 -1  1]
+//     [ 1  1  1  1  1  1],
+// l: arm length
+// c_T: thrust constant
+// c_M: moment constant
+// s: sin(30°)
+// c: cos(30°)
+//
+// The inverse can be computed computationally efficient:
+// A^-1 \approx B^pseudo * K^-1
 inline void getSquaredRotorSpeedsFromAllocationAndState(
     const Eigen::MatrixXd& allocation_inv, const Eigen::Vector3d& inertia,
     double mass, const Eigen::Vector3d& angular_velocity_B,

--- a/mav_msgs/include/mav_msgs/common.h
+++ b/mav_msgs/include/mav_msgs/common.h
@@ -170,6 +170,8 @@ inline void getSquaredRotorSpeedsFromAllocationAndState(
       inertia.asDiagonal() * angular_acceleration_B +
       angular_velocity_B.cross(inertia.asDiagonal() * angular_velocity_B);
   const double thrust_force = mass * acceleration_B.norm();
+  Eigen::Vector4d input;
+  input << torque, thrust_force;
   *rotor_rates_squared = allocation_inv * input;
 }
 

--- a/mav_msgs/include/mav_msgs/conversions.h
+++ b/mav_msgs/include/mav_msgs/conversions.h
@@ -131,6 +131,7 @@ inline void eigenTrajectoryPointFromTransformMsg(
   trajectory_point->velocity_W.setZero();
   trajectory_point->angular_velocity_W.setZero();
   trajectory_point->acceleration_W.setZero();
+  trajectory_point->angular_acceleration_W.setZero();
   trajectory_point->jerk_W.setZero();
   trajectory_point->snap_W.setZero();
 }
@@ -147,8 +148,8 @@ inline void eigenTrajectoryPointFromPoseMsg(
   trajectory_point->orientation_W_B = quaternionFromMsg(msg.pose.orientation);
   trajectory_point->velocity_W.setZero();
   trajectory_point->angular_velocity_W.setZero();
-  trajectory_point->angular_acceleration_W.setZero();
   trajectory_point->acceleration_W.setZero();
+  trajectory_point->angular_acceleration_W.setZero();
   trajectory_point->jerk_W.setZero();
   trajectory_point->snap_W.setZero();
 }
@@ -328,8 +329,10 @@ inline void eigenTrajectoryPointFromMsg(
   if (msg.accelerations.size() > 0) {
     trajectory_point->acceleration_W =
         vector3FromMsg(msg.accelerations[0].linear);
+    trajectory_point->angular_acceleration_W = vector3FromMsg(msg.accelerations[0].angular);
   } else {
     trajectory_point->acceleration_W.setZero();
+    trajectory_point->angular_acceleration_W.setZero();
   }
   trajectory_point->jerk_W.setZero();
   trajectory_point->snap_W.setZero();

--- a/mav_msgs/include/mav_msgs/conversions.h
+++ b/mav_msgs/include/mav_msgs/conversions.h
@@ -34,12 +34,12 @@
 
 #include "mav_msgs/Actuators.h"
 #include "mav_msgs/AttitudeThrust.h"
-#include "mav_msgs/common.h"
-#include "mav_msgs/default_values.h"
-#include "mav_msgs/eigen_mav_msgs.h"
 #include "mav_msgs/RateThrust.h"
 #include "mav_msgs/RollPitchYawrateThrust.h"
 #include "mav_msgs/TorqueThrust.h"
+#include "mav_msgs/common.h"
+#include "mav_msgs/default_values.h"
+#include "mav_msgs/eigen_mav_msgs.h"
 
 namespace mav_msgs {
 
@@ -112,8 +112,8 @@ inline void eigenOdometryFromMsg(const nav_msgs::Odometry& msg,
   odometry->velocity_B = mav_msgs::vector3FromMsg(msg.twist.twist.linear);
   odometry->angular_velocity_B =
       mav_msgs::vector3FromMsg(msg.twist.twist.angular);
-  odometry->pose_covariance_ = Eigen::Map<const Eigen::Matrix<double, 6, 6>>(
-      msg.pose.covariance.data());
+  odometry->pose_covariance_ =
+      Eigen::Map<const Eigen::Matrix<double, 6, 6>>(msg.pose.covariance.data());
   odometry->twist_covariance_ = Eigen::Map<const Eigen::Matrix<double, 6, 6>>(
       msg.twist.covariance.data());
 }

--- a/mav_msgs/include/mav_msgs/conversions.h
+++ b/mav_msgs/include/mav_msgs/conversions.h
@@ -147,6 +147,7 @@ inline void eigenTrajectoryPointFromPoseMsg(
   trajectory_point->orientation_W_B = quaternionFromMsg(msg.pose.orientation);
   trajectory_point->velocity_W.setZero();
   trajectory_point->angular_velocity_W.setZero();
+  trajectory_point->angular_acceleration_W.setZero();
   trajectory_point->acceleration_W.setZero();
   trajectory_point->jerk_W.setZero();
   trajectory_point->snap_W.setZero();
@@ -154,40 +155,46 @@ inline void eigenTrajectoryPointFromPoseMsg(
 
 /**
  * \brief Computes the MAV state (position, velocity, attitude, angular
- * velocity) from the flat state.
- *        Additionally, computes the acceleration expressed in body coordinates,
- * i.e. the acceleration
- *        measured by the IMU. No air-drag is assumed here.
+ * velocity, angular acceleration) from the flat state.
+ * Additionally, computes the acceleration expressed in body coordinates,
+ * i.e. the acceleration measured by the IMU. No air-drag is assumed here.
  *
  * \param[in] acceleration Acceleration of the MAV, expressed in world
  * coordinates.
  * \param[in] jerk Jerk of the MAV, expressed in world coordinates.
+ * \param[in] snap Snap of the MAV, expressed in world coordinates.
  * \param[in] yaw Yaw angle of the MAV, expressed in world coordinates.
  * \param[in] yaw_rate Yaw rate, expressed in world coordinates.
+ * \param[in] yaw_acceleration Yaw acceleration, expressed in world coordinates.
  * \param[in] magnitude_of_gravity Magnitude of the gravity vector.
  * \param[out] orientation Quaternion representing the attitude of the MAV.
  * \param[out] acceleration_body Acceleration expressed in body coordinates,
- * i.e. the acceleration usually
- *                               by the IMU.
+ * i.e. the acceleration usually by the IMU.
  * \param[out] angular_velocity_body Angular velocity of the MAV, expressed in
  * body coordinates.
+ * \param[out] angular_acceleration_body Angular acceleration of the MAV,
+ * expressed in body coordinates.
  */
 void EigenMavStateFromEigenTrajectoryPoint(
     const Eigen::Vector3d& acceleration, const Eigen::Vector3d& jerk,
-    double yaw, double yaw_rate, double magnitude_of_gravity,
+    const Eigen::Vector3d& snap, double yaw, double yaw_rate,
+    double yaw_acceleration, double magnitude_of_gravity,
     Eigen::Quaterniond* orientation, Eigen::Vector3d* acceleration_body,
-    Eigen::Vector3d* angular_velocity_body);
+    Eigen::Vector3d* angular_velocity_body,
+    Eigen::Vector3d* angular_acceleration_body);
 
 /// Convenience function with default value for the magnitude of the gravity
 /// vector.
 inline void EigenMavStateFromEigenTrajectoryPoint(
     const Eigen::Vector3d& acceleration, const Eigen::Vector3d& jerk,
-    double yaw, double yaw_rate, Eigen::Quaterniond* orientation,
-    Eigen::Vector3d* acceleration_body,
-    Eigen::Vector3d* angular_velocity_body) {
+    const Eigen::Vector3d& snap, double yaw, double yaw_rate,
+    double yaw_acceleration, Eigen::Quaterniond* orientation,
+    Eigen::Vector3d* acceleration_body, Eigen::Vector3d* angular_velocity_body,
+    Eigen::Vector3d* angular_acceleration_body) {
   EigenMavStateFromEigenTrajectoryPoint(
-      acceleration, jerk, yaw, yaw_rate, kGravity, orientation,
-      acceleration_body, angular_velocity_body);
+      acceleration, jerk, snap, yaw, yaw_rate, yaw_acceleration, kGravity,
+      orientation, acceleration_body, angular_velocity_body,
+      angular_acceleration_body);
 }
 
 /// Convenience function with EigenTrajectoryPoint as input and EigenMavState as
@@ -197,12 +204,14 @@ inline void EigenMavStateFromEigenTrajectoryPoint(
     EigenMavState* mav_state) {
   assert(mav_state != NULL);
   EigenMavStateFromEigenTrajectoryPoint(
-      flat_state.acceleration_W, flat_state.jerk_W, flat_state.getYaw(),
-      flat_state.getYawRate(), magnitude_of_gravity,
-      &(mav_state->orientation_W_B), &(mav_state->acceleration_B),
-      &(mav_state->angular_velocity_B));
+      flat_state.acceleration_W, flat_state.jerk_W, flat_state.snap_W,
+      flat_state.getYaw(), flat_state.getYawRate(), flat_state.getYawAcc(),
+      magnitude_of_gravity, &(mav_state->orientation_W_B),
+      &(mav_state->acceleration_B), &(mav_state->angular_velocity_B),
+      &(mav_state->angular_acceleration_B));
   mav_state->position_W = flat_state.position_W;
   mav_state->velocity_W = flat_state.velocity_W;
+  mav_state->rotor_rates_squared.setZero();
 }
 
 /**
@@ -217,9 +226,16 @@ inline void EigenMavStateFromEigenTrajectoryPoint(
 
 inline void EigenMavStateFromEigenTrajectoryPoint(
     const Eigen::Vector3d& acceleration, const Eigen::Vector3d& jerk,
-    double yaw, double yaw_rate, double magnitude_of_gravity,
+    const Eigen::Vector3d& snap, double yaw, double yaw_rate,
+    double yaw_acceleration, double magnitude_of_gravity,
     Eigen::Quaterniond* orientation, Eigen::Vector3d* acceleration_body,
-    Eigen::Vector3d* angular_velocity_body) {
+    Eigen::Vector3d* angular_velocity_body,
+    Eigen::Vector3d* angular_acceleration_body) {
+  // Mapping from flat state to full state following to Mellinger [1]:
+  // See [1]: Mellinger, Daniel Warren. "Trajectory generation and control for
+  //          quadrotors." (2012), Phd-thesis, p. 15ff.
+  // http://repository.upenn.edu/cgi/viewcontent.cgi?article=1705&context=edissertations
+  //
   //  zb = acc+[0 0 magnitude_of_gravity]';
   //  thrust =  norm(zb);
   //  zb = zb / thrust;
@@ -233,14 +249,16 @@ inline void EigenMavStateFromEigenTrajectoryPoint(
   //
   //  q(:,i) = rot2quat([xb yb zb]);
   //
-  //  h_w = 1/thrust*acc_dot);
+  //  h_w = 1/thrust*(acc_dot - zb' * acc_dot * zb;
   //
   //  w(1,i) = -h_w'*yb;
   //  w(2,i) = h_w'*xb;
   //  w(3,i) = yaw_dot*[0 0 1]*zb;
 
+  assert(orientation != nullptr);
   assert(acceleration_body != nullptr);
   assert(angular_velocity_body != nullptr);
+  assert(angular_acceleration_body != nullptr);
 
   Eigen::Vector3d xb;
   Eigen::Vector3d yb;
@@ -251,20 +269,31 @@ inline void EigenMavStateFromEigenTrajectoryPoint(
   const double inv_thrust = 1.0 / thrust;
   zb = zb * inv_thrust;
 
-  yb = zb.cross(Eigen::Vector3d(cos(yaw), sin(yaw), 0));
+  yb = zb.cross(Eigen::Vector3d(cos(yaw), sin(yaw), 0.0));
   yb.normalize();
 
   xb = yb.cross(zb);
 
   const Eigen::Matrix3d R((Eigen::Matrix3d() << xb, yb, zb).finished());
 
-  const Eigen::Vector3d h_w = inv_thrust * jerk;
+  const Eigen::Vector3d h_w = inv_thrust * (jerk - zb.transpose() * jerk * zb);
 
   *orientation = Eigen::Quaterniond(R);
   *acceleration_body = R.transpose() * zb * thrust;
   (*angular_velocity_body)[0] = -h_w.transpose() * yb;
   (*angular_velocity_body)[1] = h_w.transpose() * xb;
   (*angular_velocity_body)[2] = yaw_rate * zb[2];
+
+  // Calculate angular accelerations.
+  const Eigen::Vector3d wcrossz = (*angular_velocity_body).cross(zb);
+  const Eigen::Vector3d wcrosswcrossz = (*angular_velocity_body).cross(wcrossz);
+  const Eigen::Vector3d h_a = inv_thrust * (snap - zb.transpose() * snap * zb) -
+                              2 * wcrossz - wcrosswcrossz +
+                              zb.transpose() * wcrosswcrossz * zb;
+
+  (*angular_acceleration_body)[0] = -h_a.transpose() * yb;
+  (*angular_acceleration_body)[1] = h_a.transpose() * xb;
+  (*angular_acceleration_body)[2] = yaw_acceleration * zb[2];
 }
 
 inline void eigenTrajectoryPointFromMsg(

--- a/mav_msgs/include/mav_msgs/conversions.h
+++ b/mav_msgs/include/mav_msgs/conversions.h
@@ -329,7 +329,8 @@ inline void eigenTrajectoryPointFromMsg(
   if (msg.accelerations.size() > 0) {
     trajectory_point->acceleration_W =
         vector3FromMsg(msg.accelerations[0].linear);
-    trajectory_point->angular_acceleration_W = vector3FromMsg(msg.accelerations[0].angular);
+    trajectory_point->angular_acceleration_W =
+        vector3FromMsg(msg.accelerations[0].angular);
   } else {
     trajectory_point->acceleration_W.setZero();
     trajectory_point->angular_acceleration_W.setZero();

--- a/mav_msgs/include/mav_msgs/conversions.h
+++ b/mav_msgs/include/mav_msgs/conversions.h
@@ -211,7 +211,6 @@ inline void EigenMavStateFromEigenTrajectoryPoint(
       &(mav_state->angular_acceleration_B));
   mav_state->position_W = flat_state.position_W;
   mav_state->velocity_W = flat_state.velocity_W;
-  mav_state->rotor_rates_squared.setZero();
 }
 
 /**
@@ -276,7 +275,8 @@ inline void EigenMavStateFromEigenTrajectoryPoint(
 
   const Eigen::Matrix3d R((Eigen::Matrix3d() << xb, yb, zb).finished());
 
-  const Eigen::Vector3d h_w = inv_thrust * (jerk - zb.transpose() * jerk * zb);
+  const Eigen::Vector3d h_w =
+      inv_thrust * (jerk - double(zb.transpose() * jerk) * zb);
 
   *orientation = Eigen::Quaterniond(R);
   *acceleration_body = R.transpose() * zb * thrust;
@@ -287,9 +287,9 @@ inline void EigenMavStateFromEigenTrajectoryPoint(
   // Calculate angular accelerations.
   const Eigen::Vector3d wcrossz = (*angular_velocity_body).cross(zb);
   const Eigen::Vector3d wcrosswcrossz = (*angular_velocity_body).cross(wcrossz);
-  const Eigen::Vector3d h_a = inv_thrust * (snap - zb.transpose() * snap * zb) -
-                              2 * wcrossz - wcrosswcrossz +
-                              zb.transpose() * wcrosswcrossz * zb;
+  const Eigen::Vector3d h_a =
+      inv_thrust * (snap - double(zb.transpose() * snap) * zb) - 2 * wcrossz -
+      wcrosswcrossz + double(zb.transpose() * wcrosswcrossz) * zb;
 
   (*angular_acceleration_body)[0] = -h_a.transpose() * yb;
   (*angular_acceleration_body)[1] = h_a.transpose() * xb;

--- a/mav_msgs/include/mav_msgs/eigen_mav_msgs.h
+++ b/mav_msgs/include/mav_msgs/eigen_mav_msgs.h
@@ -118,23 +118,20 @@ class EigenMavState {
         acceleration_B(Eigen::Vector3d::Zero()),
         orientation_W_B(Eigen::Quaterniond::Identity()),
         angular_velocity_B(Eigen::Vector3d::Zero()),
-        angular_acceleration_B(Eigen::Vector3d::Zero()),
-        rotor_rates_squared(Eigen::VectorXd::Zero(6)){};
+        angular_acceleration_B(Eigen::Vector3d::Zero()){};
 
   EigenMavState(const Eigen::Vector3d& position_W,
                 const Eigen::Vector3d& velocity_W,
                 const Eigen::Vector3d& acceleration_B,
                 const Eigen::Quaterniond& orientation_W_B,
                 const Eigen::Vector3d& angular_velocity_B,
-                const Eigen::Vector3d& angular_acceleration_B,
-                const Eigen::VectorXd& rotor_rates_squared)
+                const Eigen::Vector3d& angular_acceleration_B)
       : position_W(position_W),
         velocity_W(velocity_W),
         acceleration_B(acceleration_B),
         orientation_W_B(orientation_W_B),
         angular_velocity_B(angular_velocity_B),
-        angular_acceleration_B(angular_acceleration_B),
-        rotor_rates_squared(rotor_rates_squared) {}
+        angular_acceleration_B(angular_acceleration_B) {}
 
   std::string toString() const {
     std::stringstream ss;
@@ -147,8 +144,6 @@ class EigenMavState {
        << "angular_velocity_body: " << angular_velocity_B.transpose()
        << std::endl
        << "angular_acceleration_body: " << angular_acceleration_B.transpose()
-       << std::endl
-       << "rotor_rates_squared: " << rotor_rates_squared.transpose()
        << std::endl;
 
     return ss.str();
@@ -160,8 +155,6 @@ class EigenMavState {
   Eigen::Quaterniond orientation_W_B;
   Eigen::Vector3d angular_velocity_B;
   Eigen::Vector3d angular_acceleration_B;
-
-  Eigen::VectorXd rotor_rates_squared;
 };
 
 struct EigenTrajectoryPoint {

--- a/mav_msgs/include/mav_msgs/eigen_mav_msgs.h
+++ b/mav_msgs/include/mav_msgs/eigen_mav_msgs.h
@@ -21,8 +21,8 @@
 #ifndef MAV_MSGS_EIGEN_MAV_MSGS_H
 #define MAV_MSGS_EIGEN_MAV_MSGS_H
 
-#include <deque>
 #include <Eigen/Eigen>
+#include <deque>
 #include <iostream>
 
 #include "mav_msgs/common.h"
@@ -32,7 +32,7 @@ namespace mav_msgs {
 struct EigenAttitudeThrust {
   EigenAttitudeThrust()
       : attitude(Eigen::Quaterniond::Identity()),
-        thrust(Eigen::Vector3d::Zero()){};
+        thrust(Eigen::Vector3d::Zero()) {}
   EigenAttitudeThrust(const Eigen::Quaterniond& _attitude,
                       const Eigen::Vector3d& _thrust) {
     attitude = _attitude;
@@ -49,7 +49,7 @@ struct EigenActuators {
 
   EigenActuators(const Eigen::VectorXd& _angular_velocities) {
     angular_velocities = _angular_velocities;
-  };
+  }
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   Eigen::VectorXd angles;              // In rad.
@@ -86,7 +86,7 @@ struct EigenTorqueThrust {
 
 struct EigenRollPitchYawrateThrust {
   EigenRollPitchYawrateThrust()
-      : roll(0.0), pitch(0.0), yaw_rate(0.0), thrust(Eigen::Vector3d::Zero()){};
+      : roll(0.0), pitch(0.0), yaw_rate(0.0), thrust(Eigen::Vector3d::Zero()) {}
 
   EigenRollPitchYawrateThrust(double _roll, double _pitch, double _yaw_rate,
                               const Eigen::Vector3d& _thrust)
@@ -107,7 +107,7 @@ struct EigenRollPitchYawrateThrust {
  */
 class EigenMavState {
  public:
-  typedef std::vector<EigenMavState, Eigen::aligned_allocator<EigenMavState> >
+  typedef std::vector<EigenMavState, Eigen::aligned_allocator<EigenMavState>>
       Vector;
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
@@ -118,7 +118,7 @@ class EigenMavState {
         acceleration_B(Eigen::Vector3d::Zero()),
         orientation_W_B(Eigen::Quaterniond::Identity()),
         angular_velocity_B(Eigen::Vector3d::Zero()),
-        angular_acceleration_B(Eigen::Vector3d::Zero()){};
+        angular_acceleration_B(Eigen::Vector3d::Zero()) {}
 
   EigenMavState(const Eigen::Vector3d& position_W,
                 const Eigen::Vector3d& velocity_W,
@@ -159,7 +159,8 @@ class EigenMavState {
 
 struct EigenTrajectoryPoint {
   typedef std::vector<EigenTrajectoryPoint,
-                      Eigen::aligned_allocator<EigenTrajectoryPoint> > Vector;
+                      Eigen::aligned_allocator<EigenTrajectoryPoint>>
+      Vector;
   EigenTrajectoryPoint()
       : timestamp_ns(-1),
         time_from_start_ns(0),
@@ -170,7 +171,7 @@ struct EigenTrajectoryPoint {
         snap_W(Eigen::Vector3d::Zero()),
         orientation_W_B(Eigen::Quaterniond::Identity()),
         angular_velocity_W(Eigen::Vector3d::Zero()),
-        angular_acceleration_W(Eigen::Vector3d::Zero()){};
+        angular_acceleration_W(Eigen::Vector3d::Zero()) {}
 
   EigenTrajectoryPoint(int64_t _time_from_start_ns,
                        const Eigen::Vector3d& _position,
@@ -204,7 +205,8 @@ struct EigenTrajectoryPoint {
                              _angular_velocity, Eigen::Vector3d::Zero()) {}
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-  int64_t timestamp_ns;  // Time since epoch, negative value = invalid timestamp.
+  int64_t
+      timestamp_ns;  // Time since epoch, negative value = invalid timestamp.
   int64_t time_from_start_ns;
   Eigen::Vector3d position_W;
   Eigen::Vector3d velocity_W;
@@ -304,10 +306,10 @@ struct EigenOdometry {
 // TODO(helenol): replaced with aligned allocator headers from Simon.
 #define MAV_MSGS_CONCATENATE(x, y) x##y
 #define MAV_MSGS_CONCATENATE2(x, y) MAV_MSGS_CONCATENATE(x, y)
-#define MAV_MSGS_MAKE_ALIGNED_CONTAINERS(EIGEN_TYPE)                     \
-  typedef std::vector<EIGEN_TYPE, Eigen::aligned_allocator<EIGEN_TYPE> > \
-      MAV_MSGS_CONCATENATE2(EIGEN_TYPE, Vector);                         \
-  typedef std::deque<EIGEN_TYPE, Eigen::aligned_allocator<EIGEN_TYPE> >  \
+#define MAV_MSGS_MAKE_ALIGNED_CONTAINERS(EIGEN_TYPE)                    \
+  typedef std::vector<EIGEN_TYPE, Eigen::aligned_allocator<EIGEN_TYPE>> \
+      MAV_MSGS_CONCATENATE2(EIGEN_TYPE, Vector);                        \
+  typedef std::deque<EIGEN_TYPE, Eigen::aligned_allocator<EIGEN_TYPE>>  \
       MAV_MSGS_CONCATENATE2(EIGEN_TYPE, Deque);
 
 MAV_MSGS_MAKE_ALIGNED_CONTAINERS(EigenAttitudeThrust)

--- a/mav_msgs/include/mav_msgs/eigen_mav_msgs.h
+++ b/mav_msgs/include/mav_msgs/eigen_mav_msgs.h
@@ -117,7 +117,24 @@ class EigenMavState {
         velocity_W(Eigen::Vector3d::Zero()),
         acceleration_B(Eigen::Vector3d::Zero()),
         orientation_W_B(Eigen::Quaterniond::Identity()),
-        angular_velocity_B(Eigen::Vector3d::Zero()){};
+        angular_velocity_B(Eigen::Vector3d::Zero()),
+        angular_acceleration_B(Eigen::Vector3d::Zero()),
+        rotor_rates_squared(Eigen::VectorXd::Zero(6)){};
+
+  EigenMavState(const Eigen::Vector3d& position_W,
+                const Eigen::Vector3d& velocity_W,
+                const Eigen::Vector3d& acceleration_B,
+                const Eigen::Quaterniond& orientation_W_B,
+                const Eigen::Vector3d& angular_velocity_B,
+                const Eigen::Vector3d& angular_acceleration_B,
+                const Eigen::VectorXd& rotor_rates_squared)
+      : position_W(position_W),
+        velocity_W(velocity_W),
+        acceleration_B(acceleration_B),
+        orientation_W_B(orientation_W_B),
+        angular_velocity_B(angular_velocity_B),
+        angular_acceleration_B(angular_acceleration_B),
+        rotor_rates_squared(rotor_rates_squared) {}
 
   std::string toString() const {
     std::stringstream ss;
@@ -128,6 +145,10 @@ class EigenMavState {
        << orientation_W_B.x() << " " << orientation_W_B.y() << " "
        << orientation_W_B.z() << " " << std::endl
        << "angular_velocity_body: " << angular_velocity_B.transpose()
+       << std::endl
+       << "angular_acceleration_body: " << angular_acceleration_B.transpose()
+       << std::endl
+       << "rotor_rates_squared: " << rotor_rates_squared.transpose()
        << std::endl;
 
     return ss.str();
@@ -138,6 +159,9 @@ class EigenMavState {
   Eigen::Vector3d acceleration_B;
   Eigen::Quaterniond orientation_W_B;
   Eigen::Vector3d angular_velocity_B;
+  Eigen::Vector3d angular_acceleration_B;
+
+  Eigen::VectorXd rotor_rates_squared;
 };
 
 struct EigenTrajectoryPoint {


### PR DESCRIPTION
- Add snap and yaw acceleration to the flat `EigenTrajectoryPoint`.
- Add angular acceleration to `EigenMavState`.
- Calculate the angular acceleration from snap and yaw acceleration in `EigenMavStateFromEigenTrajectoryPoint`.
- New method `getSquaredRotorSpeedsFromAllocationAndState` to calculate the nominal motor inputs in `common.h`.