### PR TITLE
Feature/3.3.0

### DIFF
--- a/mav_comm/CHANGELOG.rst
+++ b/mav_comm/CHANGELOG.rst
@@ -1,6 +1,11 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package mav_comm
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3.3.0 (2018-08-17)
+------------------
+* More utilities and lower level UAV kinematics, see mav_msgs changelog for details.
+* 2D polygon planning msgs, see planings_msgs changelog for details.
+
 3.1.0 (2016-12-01)
 ------------------
 * More helper functions, see mav_msgs changelog for details.
@@ -11,4 +16,3 @@ Changelog for package mav_comm
 
 2.0.3 (2015-05-22)
 ------------------
-

--- a/mav_comm/package.xml
+++ b/mav_comm/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>mav_comm</name>
-  <version>3.2.0</version>
+  <version>3.3.0</version>
   <description>Contains messages and services for MAV communication</description>
 
   <maintainer email="fadri.furrer@mavt.ethz.ch">Fadri Furrer</maintainer>
@@ -13,6 +13,8 @@
   <author>Fadri Furrer</author>
   <author>Helen Oleynikova</author>
   <author>Mina Kamel</author>
+  <author>Karen Bodie</author>
+  <author>Rik Bähnemann</author>
 
   <license>ASL 2.0</license>
 

--- a/mav_comm/package.xml
+++ b/mav_comm/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>mav_comm</name>
-  <version>3.3.0</version>
+  <version>3.2.0</version>
   <description>Contains messages and services for MAV communication</description>
 
   <maintainer email="fadri.furrer@mavt.ethz.ch">Fadri Furrer</maintainer>

--- a/mav_comm/package.xml
+++ b/mav_comm/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>mav_comm</name>
-  <version>3.2.0</version>
+  <version>3.3.0</version>
   <description>Contains messages and services for MAV communication</description>
 
   <maintainer email="fadri.furrer@mavt.ethz.ch">Fadri Furrer</maintainer>

--- a/mav_msgs/CHANGELOG.rst
+++ b/mav_msgs/CHANGELOG.rst
@@ -1,6 +1,13 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package mav_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3.3.0 (2018-08-17)
+------------------
+* Add time conversion utilities.
+* Add motor position and force default topics.
+* Add conversion from pose message to Eigen trajectory point.
+* Add angular accelerations as member of EigenMavState to calculate motor speeds.
+* Contributors: Helen Oleynikova, Karen Bodie, Rik Bähnemann
 3.2.0 (2017-03-02)
 ------------------
 * Access covariance in eigen odometry

--- a/mav_msgs/package.xml
+++ b/mav_msgs/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>mav_msgs</name>
-  <version>3.2.0</version>
+  <version>3.3.0</version>
   <description>Package containing messages for communicating with rotary wing MAVs</description>
 
   <maintainer email="fadri.furrer@mavt.ethz.ch">Fadri Furrer</maintainer>
@@ -13,6 +13,8 @@
   <author>Fadri Furrer</author>
   <author>Helen Oleynikova</author>
   <author>Mina Kamel</author>
+  <author>Karen Bodie</author>
+  <author>Rik Bähnemann</author>
 
   <license>ASL 2.0</license>
 

--- a/mav_msgs/package.xml
+++ b/mav_msgs/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>mav_msgs</name>
-  <version>3.2.0</version>
+  <version>3.3.0</version>
   <description>Package containing messages for communicating with rotary wing MAVs</description>
 
   <maintainer email="fadri.furrer@mavt.ethz.ch">Fadri Furrer</maintainer>

--- a/mav_msgs/package.xml
+++ b/mav_msgs/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>mav_msgs</name>
-  <version>3.3.0</version>
+  <version>3.2.0</version>
   <description>Package containing messages for communicating with rotary wing MAVs</description>
 
   <maintainer email="fadri.furrer@mavt.ethz.ch">Fadri Furrer</maintainer>

--- a/planning_msgs/CHANGELOG.rst
+++ b/planning_msgs/CHANGELOG.rst
@@ -1,0 +1,7 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package planning_msgs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3.3.0 (2018-08-17)
+------------------
+* 2D polygon messages and services.
+* Contributors: Rik Bähnemann

--- a/planning_msgs/package.xml
+++ b/planning_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>planning_msgs</name>
-  <version>3.2.0</version>
+  <version>3.3.0</version>
   <description>
     Messages specific to MAV planning, especially polynomial planning.
   </description>
@@ -15,6 +15,8 @@
   <author>Michael Burri</author>
   <author>Fadri Furrer</author>
   <author>Helen Oleynikova</author>
+  <author>Karen Bodie</author>
+  <author>Rik Bähnemann</author>
 
   <license>ASL 2.0</license>
 

--- a/planning_msgs/package.xml
+++ b/planning_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>planning_msgs</name>
-  <version>3.2.0</version>
+  <version>3.3.0</version>
   <description>
     Messages specific to MAV planning, especially polynomial planning.
   </description>

--- a/planning_msgs/package.xml
+++ b/planning_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>planning_msgs</name>
-  <version>3.3.0</version>
+  <version>3.2.0</version>
   <description>
     Messages specific to MAV planning, especially polynomial planning.
   </description>


### PR DESCRIPTION
Before updating should we drop the angle distance functionality https://github.com/ethz-asl/mav_comm/pull/59 and use [ros angles](https://github.com/ros/angles/blob/master/angles/include/angles/angles.h#L102) instead?

Anything else that needs to be done for a melodic release? How does that work? Would that be v4.0.0 then?