### PR TITLE
Fix ROS release dependencies.

### DIFF
--- a/mav_comm/CHANGELOG.rst
+++ b/mav_comm/CHANGELOG.rst
@@ -1,6 +1,11 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package mav_comm
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3.3.1 (2018-08-21)
+------------------
+* Change maintainer.
+* Add dependencies, see planning_msgs changelog for details.
+
 3.3.0 (2018-08-17)
 ------------------
 * More utilities and lower level UAV kinematics, see mav_msgs changelog for details.

--- a/mav_comm/package.xml
+++ b/mav_comm/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>mav_comm</name>
-  <version>3.3.0</version>
+  <version>3.3.1</version>
   <description>Contains messages and services for MAV communication</description>
 
   <maintainer email="brik@ethz.ch">Rik Bähnemann</maintainer>

--- a/mav_comm/package.xml
+++ b/mav_comm/package.xml
@@ -3,7 +3,7 @@
   <version>3.3.0</version>
   <description>Contains messages and services for MAV communication</description>
 
-  <maintainer email="fadri.furrer@mavt.ethz.ch">Fadri Furrer</maintainer>
+  <maintainer email="brik@ethz.ch">Rik Bähnemann</maintainer>
 
   <author>Simon Lynen</author>
   <author>Markus Achtelik</author>

--- a/mav_msgs/CHANGELOG.rst
+++ b/mav_msgs/CHANGELOG.rst
@@ -1,6 +1,10 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package mav_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3.3.1 (2018-08-21)
+------------------
+* Change maintainer.
+
 3.3.0 (2018-08-17)
 ------------------
 * Add time conversion utilities.

--- a/mav_msgs/CHANGELOG.rst
+++ b/mav_msgs/CHANGELOG.rst
@@ -3,6 +3,7 @@ Changelog for package mav_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 3.3.1 (2018-08-21)
 ------------------
+* Fix Eigen3 warning. Migration from Jade.
 * Change maintainer.
 
 3.3.0 (2018-08-17)

--- a/mav_msgs/CMakeLists.txt
+++ b/mav_msgs/CMakeLists.txt
@@ -4,8 +4,8 @@ project(mav_msgs)
 find_package(catkin REQUIRED cmake_modules message_generation std_msgs geometry_msgs trajectory_msgs)
 include_directories(include ${catkin_INCLUDE_DIRS})
 
-find_package(Eigen REQUIRED)
-include_directories(${EIGEN_INCLUDE_DIRS})
+find_package(Eigen3 REQUIRED)
+set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
 
 add_definitions(-std=c++11)
 
@@ -24,10 +24,8 @@ add_message_files(
 generate_messages(DEPENDENCIES std_msgs geometry_msgs)
 
 catkin_package(
-  INCLUDE_DIRS include ${EIGEN_INCLUDE_DIRS}
-  LIBRARIES
+  INCLUDE_DIRS ${EIGEN3_INCLUDE_DIRS}
   CATKIN_DEPENDS message_runtime std_msgs geometry_msgs trajectory_msgs
-  DEPENDS Eigen
   CFG_EXTRAS export_flags.cmake
 )
 

--- a/mav_msgs/package.xml
+++ b/mav_msgs/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>mav_msgs</name>
-  <version>3.3.0</version>
+  <version>3.3.1</version>
   <description>Package containing messages for communicating with rotary wing MAVs</description>
 
   <maintainer email="brik@ethz.ch">Rik Bähnemann</maintainer>

--- a/mav_msgs/package.xml
+++ b/mav_msgs/package.xml
@@ -3,7 +3,7 @@
   <version>3.3.0</version>
   <description>Package containing messages for communicating with rotary wing MAVs</description>
 
-  <maintainer email="fadri.furrer@mavt.ethz.ch">Fadri Furrer</maintainer>
+  <maintainer email="brik@ethz.ch">Rik Bähnemann</maintainer>
 
   <author>Simon Lynen</author>
   <author>Markus Achtelik</author>

--- a/mav_planning_msgs/CHANGELOG.rst
+++ b/mav_planning_msgs/CHANGELOG.rst
@@ -3,6 +3,7 @@ Changelog for package mav_planning_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 3.3.1 (2018-08-21)
 ------------------
+* Fix Eigen3 warning. Migration from Jade.
 * Add std_msgs, eigen and cmake_modules dependencies.
 
 3.3.0 (2018-08-17)

--- a/mav_planning_msgs/CHANGELOG.rst
+++ b/mav_planning_msgs/CHANGELOG.rst
@@ -1,6 +1,10 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package mav_planning_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3.3.1 (2018-08-21)
+------------------
+* Add std_msgs, eigen and cmake_modules dependencies.
+
 3.3.0 (2018-08-17)
 ------------------
 * Add 2D polygon messages and services.

--- a/mav_planning_msgs/CMakeLists.txt
+++ b/mav_planning_msgs/CMakeLists.txt
@@ -2,10 +2,10 @@ cmake_minimum_required(VERSION 2.8.3)
 project(mav_planning_msgs)
 
 find_package(catkin REQUIRED COMPONENTS geometry_msgs sensor_msgs std_msgs message_generation mav_msgs trajectory_msgs cmake_modules)
-find_package(Eigen REQUIRED)
-
 include_directories(include ${catkin_INCLUDE_DIRS})
-include_directories(${Eigen_INCLUDE_DIRS})
+
+find_package(Eigen3 REQUIRED)
+set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
 
 add_message_files(
   FILES
@@ -29,7 +29,6 @@ generate_messages(
 )
 
 catkin_package(
-  INCLUDE_DIRS include ${Eigen_INCLUDE_DIRS}
+  INCLUDE_DIRS ${Eigen_INCLUDE_DIRS}
   CATKIN_DEPENDS message_runtime geometry_msgs sensor_msgs std_msgs mav_msgs trajectory_msgs
-  DEPENDS Eigen
 )

--- a/mav_planning_msgs/CMakeLists.txt
+++ b/mav_planning_msgs/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(mav_planning_msgs)
 
-find_package(catkin REQUIRED COMPONENTS geometry_msgs sensor_msgs message_generation mav_msgs trajectory_msgs cmake_modules)
+find_package(catkin REQUIRED COMPONENTS geometry_msgs sensor_msgs std_msgs message_generation mav_msgs trajectory_msgs cmake_modules)
 find_package(Eigen REQUIRED)
 
 include_directories(include ${catkin_INCLUDE_DIRS})
@@ -25,10 +25,11 @@ add_service_files(
 )
 
 generate_messages(
-  DEPENDENCIES geometry_msgs sensor_msgs mav_msgs trajectory_msgs
+  DEPENDENCIES geometry_msgs sensor_msgs std_msgs mav_msgs trajectory_msgs
 )
 
 catkin_package(
   INCLUDE_DIRS include ${Eigen_INCLUDE_DIRS}
-  CATKIN_DEPENDS message_runtime geometry_msgs sensor_msgs mav_msgs trajectory_msgs
+  CATKIN_DEPENDS message_runtime geometry_msgs sensor_msgs std_msgs mav_msgs trajectory_msgs
+  DEPENDS Eigen
 )

--- a/mav_planning_msgs/package.xml
+++ b/mav_planning_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>mav_planning_msgs</name>
-  <version>3.3.0</version>
+  <version>3.3.1</version>
   <description>
     Messages specific to MAV planning, especially polynomial planning.
   </description>

--- a/mav_planning_msgs/package.xml
+++ b/mav_planning_msgs/package.xml
@@ -20,12 +20,18 @@
 
   <license>ASL 2.0</license>
 
+  <url type="website">https://github.com/ethz-asl/mav_comm</url>
+  <url type="bugtracker">https://github.com/ethz-asl/mav_comm/issues</url>
+
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>cmake_modules</depend>
+  <depend>eigen</depend>
   <depend>mav_msgs</depend>
   <depend>message_generation</depend>
   <depend>message_runtime</depend>
   <depend>trajectory_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
 </package>


### PR DESCRIPTION
This should fix the following ROS buildfarm error and potential other missing dependencies. Could not reproduce the error in  [prerelease](http://wiki.ros.org/regression_tests#How_do_I_setup_my_system_to_run_a_prerelease.3F) or on my machine.

```
CMake Warning at /opt/ros/indigo/share/catkin/cmake/catkinConfig.cmake:76 (find_package):
  Could not find a package configuration file provided by "cmake_modules"
  with any of the following names:

    cmake_modulesConfig.cmake
    cmake_modules-config.cmake

  Add the installation prefix of "cmake_modules" to CMAKE_PREFIX_PATH or set
  "cmake_modules_DIR" to a directory containing one of the above files.  If
  "cmake_modules" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


-- Could not find the required component 'cmake_modules'. The following CMake error indicates that you either need to install the package with the same name or change your environment so that it can be found.
CMake Error at /opt/ros/indigo/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
  Could not find a package configuration file provided by "cmake_modules"
  with any of the following names:

    cmake_modulesConfig.cmake
    cmake_modules-config.cmake

  Add the installation prefix of "cmake_modules" to CMAKE_PREFIX_PATH or set
  "cmake_modules_DIR" to a directory containing one of the above files.  If
  "cmake_modules" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)
``` 