### PR TITLE
Fix/include dirs

### DIFF
--- a/mav_msgs/CMakeLists.txt
+++ b/mav_msgs/CMakeLists.txt
@@ -24,7 +24,7 @@ add_message_files(
 generate_messages(DEPENDENCIES std_msgs geometry_msgs)
 
 catkin_package(
-  INCLUDE_DIRS ${EIGEN3_INCLUDE_DIRS}
+  INCLUDE_DIRS include ${EIGEN3_INCLUDE_DIRS}
   CATKIN_DEPENDS message_runtime std_msgs geometry_msgs trajectory_msgs
   CFG_EXTRAS export_flags.cmake
 )

--- a/mav_msgs/CMakeLists.txt
+++ b/mav_msgs/CMakeLists.txt
@@ -5,7 +5,6 @@ find_package(catkin REQUIRED cmake_modules message_generation std_msgs geometry_
 include_directories(include ${catkin_INCLUDE_DIRS})
 
 find_package(Eigen3 REQUIRED)
-set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
 
 add_definitions(-std=c++11)
 

--- a/mav_planning_msgs/CMakeLists.txt
+++ b/mav_planning_msgs/CMakeLists.txt
@@ -29,6 +29,6 @@ generate_messages(
 )
 
 catkin_package(
-  INCLUDE_DIRS ${Eigen_INCLUDE_DIRS}
+  INCLUDE_DIRS include ${Eigen_INCLUDE_DIRS}
   CATKIN_DEPENDS message_runtime geometry_msgs sensor_msgs std_msgs mav_msgs trajectory_msgs
 )

--- a/mav_planning_msgs/CMakeLists.txt
+++ b/mav_planning_msgs/CMakeLists.txt
@@ -5,7 +5,6 @@ find_package(catkin REQUIRED COMPONENTS geometry_msgs sensor_msgs std_msgs messa
 include_directories(include ${catkin_INCLUDE_DIRS})
 
 find_package(Eigen3 REQUIRED)
-set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
 
 add_message_files(
   FILES


### PR DESCRIPTION
Allows packages that depend on mav_msgs to include its files again.

Tested building [rotors_simulator](https://github.com/ethz-asl/rotors_simulator) before this (fail) and after this (succeed).