### PR TITLE
Fix/eigen dependency

### DIFF
--- a/mav_comm/CHANGELOG.rst
+++ b/mav_comm/CHANGELOG.rst
@@ -1,6 +1,10 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package mav_comm
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3.3.2 (2018-08-22)
+------------------
+* Fix indigo eigen3 compatibility.
+
 3.3.1 (2018-08-21)
 ------------------
 * Change maintainer.

--- a/mav_comm/package.xml
+++ b/mav_comm/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>mav_comm</name>
-  <version>3.3.1</version>
+  <version>3.3.2</version>
   <description>Contains messages and services for MAV communication</description>
 
   <maintainer email="brik@ethz.ch">Rik Bähnemann</maintainer>

--- a/mav_msgs/CHANGELOG.rst
+++ b/mav_msgs/CHANGELOG.rst
@@ -1,6 +1,10 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package mav_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3.3.2 (2018-08-22)
+------------------
+* Fix indigo eigen3 compatibility.
+
 3.3.1 (2018-08-21)
 ------------------
 * Fix Eigen3 warning. Migration from Jade.

--- a/mav_msgs/CMakeLists.txt
+++ b/mav_msgs/CMakeLists.txt
@@ -1,11 +1,20 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(mav_msgs)
 
-find_package(catkin REQUIRED cmake_modules message_generation std_msgs geometry_msgs trajectory_msgs)
+find_package(catkin REQUIRED message_generation std_msgs geometry_msgs trajectory_msgs)
 include_directories(include ${catkin_INCLUDE_DIRS})
 
-find_package(Eigen REQUIRED)
-include_directories(${EIGEN_INCLUDE_DIRS})
+find_package(Eigen3 QUIET)
+if(NOT EIGEN3_FOUND)
+  # ROS == Indigo.
+  find_package(cmake_modules REQUIRED)
+  find_package(Eigen REQUIRED)
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN_INCLUDE_DIRS})
+else()
+  # ROS > Indigo.
+  find_package(Eigen3 REQUIRED)
+endif()
+include_directories(${EIGEN3_INCLUDE_DIRS})
 
 add_definitions(-std=c++11)
 
@@ -24,10 +33,9 @@ add_message_files(
 generate_messages(DEPENDENCIES std_msgs geometry_msgs)
 
 catkin_package(
-  INCLUDE_DIRS include ${EIGEN_INCLUDE_DIRS}
+  INCLUDE_DIRS include ${EIGEN3_INCLUDE_DIRS}
   CATKIN_DEPENDS message_runtime std_msgs geometry_msgs trajectory_msgs
   CFG_EXTRAS export_flags.cmake
-  DEPENDS Eigen
 )
 
 install(

--- a/mav_msgs/CMakeLists.txt
+++ b/mav_msgs/CMakeLists.txt
@@ -4,7 +4,8 @@ project(mav_msgs)
 find_package(catkin REQUIRED cmake_modules message_generation std_msgs geometry_msgs trajectory_msgs)
 include_directories(include ${catkin_INCLUDE_DIRS})
 
-find_package(Eigen3 REQUIRED)
+find_package(Eigen REQUIRED)
+include_directories(${EIGEN_INCLUDE_DIRS})
 
 add_definitions(-std=c++11)
 
@@ -23,9 +24,10 @@ add_message_files(
 generate_messages(DEPENDENCIES std_msgs geometry_msgs)
 
 catkin_package(
-  INCLUDE_DIRS include ${EIGEN3_INCLUDE_DIRS}
+  INCLUDE_DIRS include ${EIGEN_INCLUDE_DIRS}
   CATKIN_DEPENDS message_runtime std_msgs geometry_msgs trajectory_msgs
   CFG_EXTRAS export_flags.cmake
+  DEPENDS Eigen
 )
 
 install(

--- a/mav_msgs/CMakeLists.txt
+++ b/mav_msgs/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT EIGEN3_FOUND)
   # ROS == Indigo.
   find_package(cmake_modules REQUIRED)
   find_package(Eigen REQUIRED)
-  set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN_INCLUDE_DIRS})
 else()
   # ROS > Indigo.
   set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})

--- a/mav_msgs/CMakeLists.txt
+++ b/mav_msgs/CMakeLists.txt
@@ -9,12 +9,11 @@ if(NOT EIGEN3_FOUND)
   # ROS == Indigo.
   find_package(cmake_modules REQUIRED)
   find_package(Eigen REQUIRED)
-  set(EIGEN3_INCLUDE_DIRS ${EIGEN_INCLUDE_DIRS})
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
 else()
   # ROS > Indigo.
-  find_package(Eigen3 REQUIRED)
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
 endif()
-include_directories(${EIGEN3_INCLUDE_DIRS})
 
 add_definitions(-std=c++11)
 

--- a/mav_msgs/package.xml
+++ b/mav_msgs/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>mav_msgs</name>
-  <version>3.3.1</version>
+  <version>3.3.2</version>
   <description>Package containing messages for communicating with rotary wing MAVs</description>
 
   <maintainer email="brik@ethz.ch">Rik Bähnemann</maintainer>

--- a/mav_msgs/package.xml
+++ b/mav_msgs/package.xml
@@ -24,13 +24,11 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>cmake_modules</build_depend>
-  <build_depend>eigen</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>trajectory_msgs</build_depend>
 
-  <run_depend>eigen</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>

--- a/mav_msgs/package.xml
+++ b/mav_msgs/package.xml
@@ -24,11 +24,13 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>cmake_modules</build_depend>
+  <build_depend>eigen</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>trajectory_msgs</build_depend>
 
+  <run_depend>eigen</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>

--- a/mav_planning_msgs/CHANGELOG.rst
+++ b/mav_planning_msgs/CHANGELOG.rst
@@ -1,6 +1,10 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package mav_planning_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3.3.2 (2018-08-22)
+------------------
+* Fix indigo eigen3 compatibility.
+
 3.3.1 (2018-08-21)
 ------------------
 * Fix Eigen3 warning. Migration from Jade.

--- a/mav_planning_msgs/CMakeLists.txt
+++ b/mav_planning_msgs/CMakeLists.txt
@@ -4,7 +4,8 @@ project(mav_planning_msgs)
 find_package(catkin REQUIRED COMPONENTS geometry_msgs sensor_msgs std_msgs message_generation mav_msgs trajectory_msgs cmake_modules)
 include_directories(include ${catkin_INCLUDE_DIRS})
 
-find_package(Eigen3 REQUIRED)
+find_package(Eigen REQUIRED)
+include_directories(${EIGEN_INCLUDE_DIRS})
 
 add_message_files(
   FILES
@@ -28,6 +29,7 @@ generate_messages(
 )
 
 catkin_package(
-  INCLUDE_DIRS include ${Eigen_INCLUDE_DIRS}
+  INCLUDE_DIRS include ${EIGEN_INCLUDE_DIRS}
   CATKIN_DEPENDS message_runtime geometry_msgs sensor_msgs std_msgs mav_msgs trajectory_msgs
+  DEPENDS Eigen
 )

--- a/mav_planning_msgs/CMakeLists.txt
+++ b/mav_planning_msgs/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT EIGEN3_FOUND)
   # ROS == Indigo.
   find_package(cmake_modules REQUIRED)
   find_package(Eigen REQUIRED)
-  set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN_INCLUDE_DIRS})
 else()
   # ROS > Indigo.
   set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})

--- a/mav_planning_msgs/CMakeLists.txt
+++ b/mav_planning_msgs/CMakeLists.txt
@@ -9,12 +9,11 @@ if(NOT EIGEN3_FOUND)
   # ROS == Indigo.
   find_package(cmake_modules REQUIRED)
   find_package(Eigen REQUIRED)
-  set(EIGEN3_INCLUDE_DIRS ${EIGEN_INCLUDE_DIRS})
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
 else()
   # ROS > Indigo.
-  find_package(Eigen3 REQUIRED)
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
 endif()
-include_directories(${EIGEN3_INCLUDE_DIRS})
 
 add_message_files(
   FILES

--- a/mav_planning_msgs/CMakeLists.txt
+++ b/mav_planning_msgs/CMakeLists.txt
@@ -1,11 +1,20 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(mav_planning_msgs)
 
-find_package(catkin REQUIRED COMPONENTS geometry_msgs sensor_msgs std_msgs message_generation mav_msgs trajectory_msgs cmake_modules)
+find_package(catkin REQUIRED COMPONENTS geometry_msgs sensor_msgs std_msgs message_generation mav_msgs trajectory_msgs)
 include_directories(include ${catkin_INCLUDE_DIRS})
 
-find_package(Eigen REQUIRED)
-include_directories(${EIGEN_INCLUDE_DIRS})
+find_package(Eigen3 QUIET)
+if(NOT EIGEN3_FOUND)
+  # ROS == Indigo.
+  find_package(cmake_modules REQUIRED)
+  find_package(Eigen REQUIRED)
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN_INCLUDE_DIRS})
+else()
+  # ROS > Indigo.
+  find_package(Eigen3 REQUIRED)
+endif()
+include_directories(${EIGEN3_INCLUDE_DIRS})
 
 add_message_files(
   FILES
@@ -29,7 +38,6 @@ generate_messages(
 )
 
 catkin_package(
-  INCLUDE_DIRS include ${EIGEN_INCLUDE_DIRS}
+  INCLUDE_DIRS include ${EIGEN3_INCLUDE_DIRS}
   CATKIN_DEPENDS message_runtime geometry_msgs sensor_msgs std_msgs mav_msgs trajectory_msgs
-  DEPENDS Eigen
 )

--- a/mav_planning_msgs/package.xml
+++ b/mav_planning_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>mav_planning_msgs</name>
-  <version>3.3.1</version>
+  <version>3.3.2</version>
   <description>
     Messages specific to MAV planning, especially polynomial planning.
   </description>

--- a/mav_planning_msgs/package.xml
+++ b/mav_planning_msgs/package.xml
@@ -26,6 +26,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>cmake_modules</depend>
+  <depend>eigen</depend>
   <depend>mav_msgs</depend>
   <depend>message_generation</depend>
   <depend>message_runtime</depend>

--- a/mav_planning_msgs/package.xml
+++ b/mav_planning_msgs/package.xml
@@ -26,7 +26,6 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>cmake_modules</depend>
-  <depend>eigen</depend>
   <depend>mav_msgs</depend>
   <depend>message_generation</depend>
   <depend>message_runtime</depend>


### PR DESCRIPTION
- Makes eigen dependency [backward compatible](http://wiki.ros.org/jade/Migration#Eigen_CMake_Module_in_cmake_modules) again.
- Prepares release 3.3.2

Bloom prerelease:
passed indigo on 16.04 local machine
passed indigo on 14.04 virtual machine
passed kinetic on 16.04 local machine
passed ~~in progress~~ lunar on 16.04 local machine
passed ~~in progress~~ melodic on 16.04 local machine