### PR TITLE
Generalize Trajectory4D and Segment4D to include 6D capabilities.

### DIFF
--- a/mav_comm/CHANGELOG.rst
+++ b/mav_comm/CHANGELOG.rst
@@ -1,6 +1,11 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package mav_comm
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3.3.3 (2019-08-16)
+------------------
+* Add 6DOF trajectory compatibility.
+* See mav_msgs and mav_planning_msgs changelogs for details.
+
 3.3.2 (2018-08-22)
 ------------------
 * Fix indigo eigen3 compatibility.

--- a/mav_comm/package.xml
+++ b/mav_comm/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>mav_comm</name>
-  <version>3.3.2</version>
+  <version>3.3.3</version>
   <description>Contains messages and services for MAV communication</description>
 
   <maintainer email="brik@ethz.ch">Rik Bähnemann</maintainer>

--- a/mav_msgs/CHANGELOG.rst
+++ b/mav_msgs/CHANGELOG.rst
@@ -1,6 +1,14 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package mav_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3.3.3 (2019-08-16)
+------------------
+* Add `degrees_of_freedom` to EigenTrajectoryPoint for 6DOF compatibility.
+* Add functions to common.h:
+*   skewMatrixFromVector, vectorFromSkewMatrix, isRotationMatrix, 
+*   matrixFromRotationVector, vectorFromRotationMatrix, omegaFromRotationVector
+*   omegaDotFromRotationVector
+
 3.3.2 (2018-08-22)
 ------------------
 * Fix indigo eigen3 compatibility.

--- a/mav_msgs/include/mav_msgs/common.h
+++ b/mav_msgs/include/mav_msgs/common.h
@@ -161,6 +161,19 @@ inline void vectorFromSkewMatrix(const Eigen::Matrix3d& vec_skew,
   }
 }
 
+inline bool isRotationMatrix(const Eigen::Matrix3d& mat){
+  // Check that R^T * R = I
+  if ((mat.transpose() * mat - Eigen::Matrix3d::Identity()).norm() > 1e-6){
+    std::cerr << "[mav_msgs::common] Rotation matrix requirement violated (R^T * R = I)" << std::endl;
+    return false;
+  }  
+  // Check that det(R) = 1
+  if (mat.determinant() - 1.0 > 1e-6){
+    std::cerr << "[mav_msgs::common] Rotation matrix requirement violated (det(R) = 1)" << std::endl;
+    return false;
+  }  
+}
+
 // Rotation matrix from rotation vector as described in 
 // "Computationally Efficient Trajectory Generation for Fully Actuated Multirotor Vehicles"
 // Brescianini 2018
@@ -187,9 +200,9 @@ inline void vectorFromRotationMatrix(const Eigen::Matrix3d& mat,
   // and phi satisfies 1 + 2cos(phi) = trace(R)
   assert(vec);
   
-  // if (!isRotationMatrix(mat)){
-  //   std::cerr << "[mav_msgs::common] Not a rotation matrix." << std::endl;
-  // }
+  if (!isRotationMatrix(mat)){
+    std::cerr << "[mav_msgs::common] Not a rotation matrix." << std::endl;
+  }
   
   if ((mat - Eigen::Matrix3d::Identity()).norm() < 1e-6){
     *vec = Eigen::Vector3d::Zero();
@@ -209,23 +222,9 @@ inline void vectorFromRotationMatrix(const Eigen::Matrix3d& mat,
   } else{
     Eigen::Matrix3d vec_skew = (mat - mat.transpose()) * phi / (2.0 * std::sin(phi));
     Eigen::Vector3d vec_unskewed;
-    std::cerr << "[mav_msgs::common] vec_skew = " << vec_skew << std::endl;
     vectorFromSkewMatrix(vec_skew, &vec_unskewed);
     *vec = vec_unskewed;
   }
-}
-
-inline bool isRotationMatrix(const Eigen::Matrix3d& mat){
-  // Check that R^T * R = I
-  if ((mat.transpose() * mat - Eigen::Matrix3d::Identity()).norm() > 1e-6){
-    std::cerr << "[mav_msgs::common] Rotation matrix requirement violated (R^T * R = I)" << std::endl;
-    return false;
-  }  
-  // Check that det(R) = 1
-  if (mat.determinant() - 1.0 > 1e-6){
-    std::cerr << "[mav_msgs::common] Rotation matrix requirement violated (det(R) = 1)" << std::endl;
-    return false;
-  }  
 }
 
 // Calculates angular velocity (omega) from rotation vector derivative

--- a/mav_msgs/include/mav_msgs/eigen_mav_msgs.h
+++ b/mav_msgs/include/mav_msgs/eigen_mav_msgs.h
@@ -28,6 +28,9 @@
 #include "mav_msgs/common.h"
 
 namespace mav_msgs {
+  
+/// Actuated degrees of freedom.
+enum MavActuation { DOF4 = 4, DOF6 = 6 };
 
 struct EigenAttitudeThrust {
   EigenAttitudeThrust()
@@ -170,7 +173,8 @@ struct EigenTrajectoryPoint {
         snap_W(Eigen::Vector3d::Zero()),
         orientation_W_B(Eigen::Quaterniond::Identity()),
         angular_velocity_W(Eigen::Vector3d::Zero()),
-        angular_acceleration_W(Eigen::Vector3d::Zero()) {}
+        angular_acceleration_W(Eigen::Vector3d::Zero()),
+        degrees_of_freedom(MavActuation::DOF4) {}
 
   EigenTrajectoryPoint(int64_t _time_from_start_ns,
                        const Eigen::Vector3d& _position,
@@ -180,7 +184,8 @@ struct EigenTrajectoryPoint {
                        const Eigen::Vector3d& _snap,
                        const Eigen::Quaterniond& _orientation,
                        const Eigen::Vector3d& _angular_velocity,
-                       const Eigen::Vector3d& _angular_acceleration)
+                       const Eigen::Vector3d& _angular_acceleration,
+                       const MavActuation& _degrees_of_freedom = MavActuation::DOF4)
       : time_from_start_ns(_time_from_start_ns),
         position_W(_position),
         velocity_W(_velocity),
@@ -189,7 +194,8 @@ struct EigenTrajectoryPoint {
         snap_W(_snap),
         orientation_W_B(_orientation),
         angular_velocity_W(_angular_velocity),
-        angular_acceleration_W(_angular_acceleration) {}
+        angular_acceleration_W(_angular_acceleration),
+        degrees_of_freedom(_degrees_of_freedom) {}
 
   EigenTrajectoryPoint(int64_t _time_from_start_ns,
                        const Eigen::Vector3d& _position,
@@ -198,14 +204,16 @@ struct EigenTrajectoryPoint {
                        const Eigen::Vector3d& _jerk,
                        const Eigen::Vector3d& _snap,
                        const Eigen::Quaterniond& _orientation,
-                       const Eigen::Vector3d& _angular_velocity)
+                       const Eigen::Vector3d& _angular_velocity,
+                       const MavActuation& _degrees_of_freedom = MavActuation::DOF4)
       : EigenTrajectoryPoint(_time_from_start_ns, _position, _velocity,
                              _acceleration, _jerk, _snap, _orientation,
-                             _angular_velocity, Eigen::Vector3d::Zero()) {}
+                             _angular_velocity, Eigen::Vector3d::Zero(), _degrees_of_freedom) {}
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   int64_t timestamp_ns;  // Time since epoch, negative value = invalid timestamp.
   int64_t time_from_start_ns;
+  MavActuation degrees_of_freedom;
   Eigen::Vector3d position_W;
   Eigen::Vector3d velocity_W;
   Eigen::Vector3d acceleration_W;

--- a/mav_msgs/package.xml
+++ b/mav_msgs/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>mav_msgs</name>
-  <version>3.3.2</version>
+  <version>3.3.3</version>
   <description>Package containing messages for communicating with rotary wing MAVs</description>
 
   <maintainer email="brik@ethz.ch">Rik Bähnemann</maintainer>

--- a/mav_planning_msgs/CHANGELOG.rst
+++ b/mav_planning_msgs/CHANGELOG.rst
@@ -1,6 +1,12 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package mav_planning_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3.3.3 (2019-08-16)
+------------------
+* Add PolynomialSegment/Trajectory messages with 3D rotation vector.
+* Update conversions, deprecate old conversions.
+* Update planner service to take 4D or full trajectory message
+
 3.3.2 (2018-08-22)
 ------------------
 * Fix indigo eigen3 compatibility.

--- a/mav_planning_msgs/CMakeLists.txt
+++ b/mav_planning_msgs/CMakeLists.txt
@@ -24,6 +24,8 @@ add_message_files(
   PolygonWithHolesStamped.msg
   PolynomialSegment.msg
   PolynomialTrajectory.msg
+  PolynomialSegment4D.msg
+  PolynomialTrajectory4D.msg
 )
 
 add_service_files(

--- a/mav_planning_msgs/CMakeLists.txt
+++ b/mav_planning_msgs/CMakeLists.txt
@@ -22,8 +22,8 @@ add_message_files(
   Polygon2D.msg
   PolygonWithHoles.msg
   PolygonWithHolesStamped.msg
-  PolynomialSegment4D.msg
-  PolynomialTrajectory4D.msg
+  PolynomialSegment.msg
+  PolynomialTrajectory.msg
 )
 
 add_service_files(

--- a/mav_planning_msgs/include/mav_planning_msgs/conversions.h
+++ b/mav_planning_msgs/include/mav_planning_msgs/conversions.h
@@ -23,21 +23,21 @@
 #include <geometry_msgs/Quaternion.h>
 #include <geometry_msgs/Vector3.h>
 
-#include "mav_planning_msgs/PolynomialSegment4D.h"
-#include "mav_planning_msgs/PolynomialTrajectory4D.h"
+#include "mav_planning_msgs/PolynomialSegment.h"
+#include "mav_planning_msgs/PolynomialTrajectory.h"
 #include "mav_planning_msgs/eigen_planning_msgs.h"
 
 namespace mav_planning_msgs {
 
 /// Converts a PolynomialSegment double array to an Eigen::VectorXd.
-inline void vectorFromMsgArray(const PolynomialSegment4D::_x_type& array,
+inline void vectorFromMsgArray(const PolynomialSegment::_x_type& array,
                                Eigen::VectorXd* x) {
   *x = Eigen::Map<const Eigen::VectorXd>(&(array[0]), array.size());
 }
 
 /// Converts an Eigen::VectorXd to a PolynomialSegment double array.
 inline void msgArrayFromVector(const Eigen::VectorXd& x,
-                               PolynomialSegment4D::_x_type* array) {
+                               PolynomialSegment::_x_type* array) {
   array->resize(x.size());
   Eigen::Map<Eigen::VectorXd> map =
       Eigen::Map<Eigen::VectorXd>(&((*array)[0]), array->size());
@@ -45,7 +45,7 @@ inline void msgArrayFromVector(const Eigen::VectorXd& x,
 }
 
 /// Converts a PolynomialSegment message to an EigenPolynomialSegment structure.
-inline void eigenPolynomialSegmentFromMsg(const PolynomialSegment4D& msg,
+inline void eigenPolynomialSegmentFromMsg(const PolynomialSegment& msg,
                                           EigenPolynomialSegment* segment) {
   assert(segment != NULL);
 
@@ -53,6 +53,9 @@ inline void eigenPolynomialSegmentFromMsg(const PolynomialSegment4D& msg,
   vectorFromMsgArray(msg.y, &(segment->y));
   vectorFromMsgArray(msg.z, &(segment->z));
   vectorFromMsgArray(msg.yaw, &(segment->yaw));
+  vectorFromMsgArray(msg.rx, &(segment->rx));
+  vectorFromMsgArray(msg.ry, &(segment->ry));
+  vectorFromMsgArray(msg.rz, &(segment->rz));
 
   segment->segment_time_ns = msg.segment_time.toNSec();
   segment->num_coeffs = msg.num_coeffs;
@@ -60,12 +63,12 @@ inline void eigenPolynomialSegmentFromMsg(const PolynomialSegment4D& msg,
 
 /// Converts a PolynomialTrajectory message to a EigenPolynomialTrajectory
 inline void eigenPolynomialTrajectoryFromMsg(
-    const PolynomialTrajectory4D& msg,
+    const PolynomialTrajectory& msg,
     EigenPolynomialTrajectory* eigen_trajectory) {
   assert(eigen_trajectory != NULL);
   eigen_trajectory->clear();
   eigen_trajectory->reserve(msg.segments.size());
-  for (PolynomialTrajectory4D::_segments_type::const_iterator it =
+  for (PolynomialTrajectory::_segments_type::const_iterator it =
            msg.segments.begin();
        it != msg.segments.end(); ++it) {
     EigenPolynomialSegment segment;
@@ -77,12 +80,15 @@ inline void eigenPolynomialTrajectoryFromMsg(
 /// Converts an EigenPolynomialSegment to a PolynomialSegment message. Does NOT
 /// set the header!
 inline void polynomialSegmentMsgFromEigen(const EigenPolynomialSegment& segment,
-                                          PolynomialSegment4D* msg) {
+                                          PolynomialSegment* msg) {
   assert(msg != NULL);
   msgArrayFromVector(segment.x, &(msg->x));
   msgArrayFromVector(segment.y, &(msg->y));
   msgArrayFromVector(segment.z, &(msg->z));
   msgArrayFromVector(segment.yaw, &(msg->yaw));
+  msgArrayFromVector(segment.rx, &(msg->rx));
+  msgArrayFromVector(segment.ry, &(msg->ry));
+  msgArrayFromVector(segment.rz, &(msg->rz));
 
   msg->segment_time.fromNSec(segment.segment_time_ns);
   msg->num_coeffs = segment.num_coeffs;
@@ -92,12 +98,12 @@ inline void polynomialSegmentMsgFromEigen(const EigenPolynomialSegment& segment,
 /// Does NOT set the header!
 inline void polynomialTrajectoryMsgFromEigen(
     const EigenPolynomialTrajectory& eigen_trajectory,
-    PolynomialTrajectory4D* msg) {
+    PolynomialTrajectory* msg) {
   assert(msg != NULL);
   msg->segments.reserve(eigen_trajectory.size());
   for (EigenPolynomialTrajectory::const_iterator it = eigen_trajectory.begin();
        it != eigen_trajectory.end(); ++it) {
-    PolynomialSegment4D segment;
+    PolynomialSegment segment;
     polynomialSegmentMsgFromEigen(*it, &segment);
     msg->segments.push_back(segment);
   }

--- a/mav_planning_msgs/include/mav_planning_msgs/conversions.h
+++ b/mav_planning_msgs/include/mav_planning_msgs/conversions.h
@@ -27,6 +27,9 @@
 #include "mav_planning_msgs/PolynomialTrajectory.h"
 #include "mav_planning_msgs/eigen_planning_msgs.h"
 
+// deprecated
+#include "mav_planning_msgs/conversions_deprecated.h"
+
 namespace mav_planning_msgs {
 
 /// Converts a PolynomialSegment double array to an Eigen::VectorXd.

--- a/mav_planning_msgs/include/mav_planning_msgs/conversions_deprecated.h
+++ b/mav_planning_msgs/include/mav_planning_msgs/conversions_deprecated.h
@@ -29,16 +29,16 @@
 
 namespace mav_planning_msgs {
   
-  /// Converts a PolynomialSegment double array to an Eigen::VectorXd.
-  void vectorFromMsgArray(const PolynomialSegment4D::_x_type& array,
-                                 Eigen::VectorXd* x);
+/// Converts a PolynomialSegment double array to an Eigen::VectorXd.
+inline void vectorFromMsgArray(const PolynomialSegment4D::_x_type& array,
+                               Eigen::VectorXd* x);
 
-  /// Converts an Eigen::VectorXd to a PolynomialSegment double array.
-  void msgArrayFromVector(const Eigen::VectorXd& x,
-                                 PolynomialSegment4D::_x_type* array);
+/// Converts an Eigen::VectorXd to a PolynomialSegment double array.
+inline void msgArrayFromVector(const Eigen::VectorXd& x,
+                               PolynomialSegment4D::_x_type* array);
 
 /// Converts a PolynomialSegment message to an EigenPolynomialSegment structure.
-void eigenPolynomialSegmentFromMsg(const PolynomialSegment4D& msg,
+inline void eigenPolynomialSegmentFromMsg(const PolynomialSegment4D& msg,
                                           EigenPolynomialSegment* segment) {
   assert(segment != NULL);
 
@@ -52,7 +52,7 @@ void eigenPolynomialSegmentFromMsg(const PolynomialSegment4D& msg,
 }
 
 /// Converts a PolynomialTrajectory message to a EigenPolynomialTrajectory
-void eigenPolynomialTrajectoryFromMsg(
+inline void eigenPolynomialTrajectoryFromMsg(
     const PolynomialTrajectory4D& msg,
     EigenPolynomialTrajectory* eigen_trajectory) {
   assert(eigen_trajectory != NULL);
@@ -70,7 +70,7 @@ void eigenPolynomialTrajectoryFromMsg(
 
 /// Converts an EigenPolynomialSegment to a PolynomialSegment message. Does NOT
 /// set the header!
-void polynomialSegmentMsgFromEigen(const EigenPolynomialSegment& segment,
+inline void polynomialSegmentMsgFromEigen(const EigenPolynomialSegment& segment,
                                           PolynomialSegment4D* msg) {
   assert(msg != NULL);
   msgArrayFromVector(segment.x, &(msg->x));
@@ -84,7 +84,7 @@ void polynomialSegmentMsgFromEigen(const EigenPolynomialSegment& segment,
 
 /// Converts an EigenPolynomialTrajectory to a PolynomialTrajectory message.
 /// Does NOT set the header!
-void polynomialTrajectoryMsgFromEigen(
+inline void polynomialTrajectoryMsgFromEigen(
     const EigenPolynomialTrajectory& eigen_trajectory,
     PolynomialTrajectory4D* msg) {
   assert(msg != NULL);

--- a/mav_planning_msgs/include/mav_planning_msgs/conversions_deprecated.h
+++ b/mav_planning_msgs/include/mav_planning_msgs/conversions_deprecated.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2015 Fadri Furrer, ASL, ETH Zurich, Switzerland
+ * Copyright 2015 Michael Burri, ASL, ETH Zurich, Switzerland
+ * Copyright 2015 Markus Achtelik, ASL, ETH Zurich, Switzerland
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MAV_PLANNING_MSGS_CONVERSIONS_DEPRECATED_H
+#define MAV_PLANNING_MSGS_CONVERSIONS_DEPRECATED_H
+
+#include <geometry_msgs/Point.h>
+#include <geometry_msgs/Quaternion.h>
+#include <geometry_msgs/Vector3.h>
+
+#include "mav_planning_msgs/PolynomialSegment4D.h"
+#include "mav_planning_msgs/PolynomialTrajectory4D.h"
+#include "mav_planning_msgs/eigen_planning_msgs.h"
+
+namespace mav_planning_msgs {
+  
+  /// Converts a PolynomialSegment double array to an Eigen::VectorXd.
+  void vectorFromMsgArray(const PolynomialSegment4D::_x_type& array,
+                                 Eigen::VectorXd* x);
+
+  /// Converts an Eigen::VectorXd to a PolynomialSegment double array.
+  void msgArrayFromVector(const Eigen::VectorXd& x,
+                                 PolynomialSegment4D::_x_type* array);
+
+/// Converts a PolynomialSegment message to an EigenPolynomialSegment structure.
+void eigenPolynomialSegmentFromMsg(const PolynomialSegment4D& msg,
+                                          EigenPolynomialSegment* segment) {
+  assert(segment != NULL);
+
+  vectorFromMsgArray(msg.x, &(segment->x));
+  vectorFromMsgArray(msg.y, &(segment->y));
+  vectorFromMsgArray(msg.z, &(segment->z));
+  vectorFromMsgArray(msg.yaw, &(segment->yaw));
+
+  segment->segment_time_ns = msg.segment_time.toNSec();
+  segment->num_coeffs = msg.num_coeffs;
+}
+
+/// Converts a PolynomialTrajectory message to a EigenPolynomialTrajectory
+void eigenPolynomialTrajectoryFromMsg(
+    const PolynomialTrajectory4D& msg,
+    EigenPolynomialTrajectory* eigen_trajectory) {
+  assert(eigen_trajectory != NULL);
+  eigen_trajectory->clear();
+  eigen_trajectory->reserve(msg.segments.size());
+  for (PolynomialTrajectory4D::_segments_type::const_iterator it =
+           msg.segments.begin();
+       it != msg.segments.end(); ++it) {
+    EigenPolynomialSegment segment;
+    eigenPolynomialSegmentFromMsg(*it, &segment);
+    eigen_trajectory->push_back(segment);
+  }
+}
+
+
+/// Converts an EigenPolynomialSegment to a PolynomialSegment message. Does NOT
+/// set the header!
+void polynomialSegmentMsgFromEigen(const EigenPolynomialSegment& segment,
+                                          PolynomialSegment4D* msg) {
+  assert(msg != NULL);
+  msgArrayFromVector(segment.x, &(msg->x));
+  msgArrayFromVector(segment.y, &(msg->y));
+  msgArrayFromVector(segment.z, &(msg->z));
+  msgArrayFromVector(segment.yaw, &(msg->yaw));
+
+  msg->segment_time.fromNSec(segment.segment_time_ns);
+  msg->num_coeffs = segment.num_coeffs;
+}
+
+/// Converts an EigenPolynomialTrajectory to a PolynomialTrajectory message.
+/// Does NOT set the header!
+void polynomialTrajectoryMsgFromEigen(
+    const EigenPolynomialTrajectory& eigen_trajectory,
+    PolynomialTrajectory4D* msg) {
+  assert(msg != NULL);
+  msg->segments.reserve(eigen_trajectory.size());
+  for (EigenPolynomialTrajectory::const_iterator it = eigen_trajectory.begin();
+       it != eigen_trajectory.end(); ++it) {
+    PolynomialSegment4D segment;
+    polynomialSegmentMsgFromEigen(*it, &segment);
+    msg->segments.push_back(segment);
+  }
+}
+
+}  // namespace mav_planning_msgs
+
+#endif // MAV_PLANNING_MSGS_CONVERSIONS_DEPRECATED_H

--- a/mav_planning_msgs/include/mav_planning_msgs/eigen_planning_msgs.h
+++ b/mav_planning_msgs/include/mav_planning_msgs/eigen_planning_msgs.h
@@ -31,6 +31,9 @@ struct EigenPolynomialSegment {
   Eigen::VectorXd y;
   Eigen::VectorXd z;
   Eigen::VectorXd yaw;
+  Eigen::VectorXd rx;
+  Eigen::VectorXd ry;
+  Eigen::VectorXd rz;
   uint64_t segment_time_ns;
   int num_coeffs;
 };

--- a/mav_planning_msgs/msg/PolynomialSegment.msg
+++ b/mav_planning_msgs/msg/PolynomialSegment.msg
@@ -4,4 +4,7 @@ duration segment_time   # duration of the segment
 float64[] x             # coefficients for the x-axis, INCREASING order
 float64[] y             # coefficients for the y-axis, INCREASING order
 float64[] z             # coefficients for the z-axis, INCREASING order
-float64[] yaw           # coefficients for the yaw,    INCREASING order
+float64[] yaw           # coefficients for the yaw, INCREASING order
+float64[] rx            # coefficients for the rotation x-vector, INCREASING order
+float64[] ry            # coefficients for the rotation y-vector, INCREASING order
+float64[] rz            # coefficients for the rotation z-vector, INCREASING order

--- a/mav_planning_msgs/msg/PolynomialSegment4D.msg
+++ b/mav_planning_msgs/msg/PolynomialSegment4D.msg
@@ -1,0 +1,7 @@
+Header header
+int32 num_coeffs        # order of the polynomial + 1, should match size of x[]
+duration segment_time   # duration of the segment
+float64[] x             # coefficients for the x-axis, INCREASING order
+float64[] y             # coefficients for the y-axis, INCREASING order
+float64[] z             # coefficients for the z-axis, INCREASING order
+float64[] yaw           # coefficients for the yaw, INCREASING order

--- a/mav_planning_msgs/msg/PolynomialTrajectory.msg
+++ b/mav_planning_msgs/msg/PolynomialTrajectory.msg
@@ -1,0 +1,2 @@
+Header header
+PolynomialSegment[] segments

--- a/mav_planning_msgs/msg/PolynomialTrajectory4D.msg
+++ b/mav_planning_msgs/msg/PolynomialTrajectory4D.msg
@@ -1,0 +1,2 @@
+Header header
+PolynomialSegment4D[] segments

--- a/mav_planning_msgs/msg/PolynomialTrajectory4D.msg
+++ b/mav_planning_msgs/msg/PolynomialTrajectory4D.msg
@@ -1,2 +1,0 @@
-Header header
-PolynomialSegment4D[] segments

--- a/mav_planning_msgs/package.xml
+++ b/mav_planning_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>mav_planning_msgs</name>
-  <version>3.3.2</version>
+  <version>3.3.3</version>
   <description>
     Messages specific to MAV planning, especially polynomial planning.
   </description>

--- a/mav_planning_msgs/srv/PlannerService.srv
+++ b/mav_planning_msgs/srv/PlannerService.srv
@@ -8,7 +8,7 @@ geometry_msgs/Vector3 bounding_box
 # True on success, false on planning failure
 bool success
 # Either contains a polynomial trajectory:
-mav_planning_msgs/PolynomialTrajectory4D polynomial_plan
+mav_planning_msgs/PolynomialTrajectory polynomial_plan
 # or a MultiDOFJointTrajectory containing a sampled path (or straight-line
 # waypoints, depending on the planner).
 # Only one of these should be non-empty.

--- a/mav_planning_msgs/srv/PlannerService.srv
+++ b/mav_planning_msgs/srv/PlannerService.srv
@@ -9,6 +9,7 @@ geometry_msgs/Vector3 bounding_box
 bool success
 # Either contains a polynomial trajectory:
 mav_planning_msgs/PolynomialTrajectory polynomial_plan
+mav_planning_msgs/PolynomialTrajectory4D polynomial_plan_4D
 # or a MultiDOFJointTrajectory containing a sampled path (or straight-line
 # waypoints, depending on the planner).
 # Only one of these should be non-empty.


### PR DESCRIPTION
This extension changes two mav_planning_msgs: 
PolynomialSegment4D andPolynomialTrajectory4D to
PolynomialSegment and PolynomialTrajectory.

Messages have additional fields: 
float64[] rx            # coefficients for the rotation x-vector, INCREASING order
float64[] ry            # coefficients for the rotation y-vector, INCREASING order
float64[] rz            # coefficients for the rotation z-vector, INCREASING order

Apart from the message name, functionality is backwards compatible.

Tested with mav_trajectory generation on 6D branch: feature/overactuated_pullup