### PR TITLE
Add missing nav_msgs dependency

### DIFF
--- a/mav_msgs/CMakeLists.txt
+++ b/mav_msgs/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(mav_msgs)
 
-find_package(catkin REQUIRED message_generation std_msgs geometry_msgs trajectory_msgs)
+find_package(catkin REQUIRED message_generation std_msgs geometry_msgs trajectory_msgs nav_msgs)
 include_directories(include ${catkin_INCLUDE_DIRS})
 
 find_package(Eigen3 QUIET)
@@ -29,11 +29,11 @@ add_message_files(
   GpsWaypoint.msg
 )
 
-generate_messages(DEPENDENCIES std_msgs geometry_msgs)
+generate_messages(DEPENDENCIES std_msgs geometry_msgs nav_msgs)
 
 catkin_package(
   INCLUDE_DIRS include ${EIGEN3_INCLUDE_DIRS}
-  CATKIN_DEPENDS message_runtime std_msgs geometry_msgs trajectory_msgs
+  CATKIN_DEPENDS message_runtime std_msgs geometry_msgs trajectory_msgs nav_msgs
   CFG_EXTRAS export_flags.cmake
 )
 

--- a/mav_msgs/package.xml
+++ b/mav_msgs/package.xml
@@ -27,12 +27,14 @@
   <build_depend>eigen</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>message_generation</build_depend>
+  <build_depend>nav_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>trajectory_msgs</build_depend>
-
+  
   <run_depend>eigen</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
+  <run_depend>nav_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>trajectory_msgs</run_depend>
 


### PR DESCRIPTION
A minor change, but necessary to build `mav_msgs` properly when using a from-source installation of ROS.