### PR TITLE
Add missing dependency rosidl_default_generators

### DIFF
--- a/mav_state_machine_msgs/CMakeLists.txt
+++ b/mav_state_machine_msgs/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 
 find_package(std_msgs REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   msg/StartStopTask.msg

--- a/mav_system_msgs/CMakeLists.txt
+++ b/mav_system_msgs/CMakeLists.txt
@@ -6,6 +6,7 @@ if(${CMAKE_VERSION} VERSION_GREATER 3.27)
 endif()
 
 find_package(std_msgs REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   msg/CpuInfo.msg


### PR DESCRIPTION
Resolve compilation issue caused by missing dependency.

### Details  

System: macOS 15.2 (Sequoia), Xcode 16.2
ROS 2: Jazzy, Rolling

The proposed change resolves the following build error: 

```bash
% colcon build --symlink-install --cmake-args -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=17 -DPython3_EXECUTABLE=$(which python3) --packages-select mav_state_machine_msgs
Starting >>> mav_state_machine_msgs
--- stderr: mav_state_machine_msgs                         
CMake Error at CMakeLists.txt:12 (rosidl_generate_interfaces):
  Unknown CMake command "rosidl_generate_interfaces".


---
Failed   <<< mav_state_machine_msgs [6.53s, exited with code 1]
```